### PR TITLE
Hash once instead of twice

### DIFF
--- a/2018/day-01/src/main.rs
+++ b/2018/day-01/src/main.rs
@@ -23,15 +23,12 @@ pub fn part_two(init_freq: Frequency, input: &str) -> io::Result<Frequency> {
         .cycle();
     for change in iter {
         res += change;
-        if seen.contains(&res) {
-            break;
-        }
-        seen.insert(res);
+        if !seen.insert(res) { break; }
     }
     Ok(res)
 }
 
-fn main() -> io::Result<()> {
+fn main() -> Result<(), Box<std::error::Error>> {
     let input_path = String::from("INPUT");
     let input = fs::read_to_string(&input_path)?;
 


### PR DESCRIPTION
`seen.insert` returns a bool depending on whether the value is present
in the HashSet. We can use this return value instead of `seen.contains`
to save one hash.

Thanks @mmun for the protip!

Also, change the return type for `main` to be more idiomatic. This will
let us preserve the error type instead of forcing all errors to be io
errors. (From:
https://www.reddit.com/r/rust/comments/8ilg97/small_tip_on_new_main_result_behavior/)